### PR TITLE
WIP: Support real integration testing

### DIFF
--- a/Starcounter.Database.Extensions.sln
+++ b/Starcounter.Database.Extensions.sln
@@ -26,6 +26,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NestedTransactions", "samples\NestedTransactions\NestedTransactions.csproj", "{F79A70C9-9333-4987-9754-A62B2496CB1B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -44,6 +46,10 @@ Global
 		{B7653081-D17A-4DC5-8192-648864B130ED}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B7653081-D17A-4DC5-8192-648864B130ED}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B7653081-D17A-4DC5-8192-648864B130ED}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F79A70C9-9333-4987-9754-A62B2496CB1B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F79A70C9-9333-4987-9754-A62B2496CB1B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F79A70C9-9333-4987-9754-A62B2496CB1B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F79A70C9-9333-4987-9754-A62B2496CB1B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -52,6 +58,7 @@ Global
 		{360D65A5-6EF9-4BBE-BE9A-38F15D6BDF45} = {95830FC9-D2A9-4C23-ADF5-47FAAFAD2390}
 		{44C71177-FAAA-4E08-A097-5BFA3E5D6BB5} = {A7FF5EC3-CEB2-4B59-AA80-8E0CCC64A805}
 		{B7653081-D17A-4DC5-8192-648864B130ED} = {16D71DAA-401E-4400-8950-67429554CCDB}
+		{F79A70C9-9333-4987-9754-A62B2496CB1B} = {16D71DAA-401E-4400-8950-67429554CCDB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B2CDA871-6A0E-4E5B-9F24-CE51B128680C}

--- a/samples/Hooks/Hooks.csproj
+++ b/samples/Hooks/Hooks.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Starcounter.Database" Version="3.0.0-rc" />
+    <PackageReference Include="Starcounter.Database" Version="3.0.0-rc-*" />
     <PackageReference Include="Scrutor" Version="3.2.0" />
   </ItemGroup>
 

--- a/samples/NestedTransactions/NestedTransactions.csproj
+++ b/samples/NestedTransactions/NestedTransactions.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Starcounter.Database" Version="3.0.0-rc" />
+    <PackageReference Include="Scrutor" Version="3.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Starcounter.Database.Extensions\Starcounter.Database.Extensions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/NestedTransactions/NestedTransactions.csproj
+++ b/samples/NestedTransactions/NestedTransactions.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Starcounter.Database" Version="3.0.0-rc" />
+    <PackageReference Include="Starcounter.Database" Version="3.0.0-rc-*" />
     <PackageReference Include="Scrutor" Version="3.2.0" />
   </ItemGroup>
 

--- a/samples/NestedTransactions/NestedTransactions.csproj
+++ b/samples/NestedTransactions/NestedTransactions.csproj
@@ -6,12 +6,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Starcounter.Database" Version="3.0.0-rc" />
     <PackageReference Include="Scrutor" Version="3.2.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Starcounter.Database.Extensions\Starcounter.Database.Extensions.csproj" />
+    <ProjectReference Include="..\..\..\Starcounter.Nova\src\Starcounter.Database\Starcounter.Database.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/NestedTransactions/NestedTransactions.csproj
+++ b/samples/NestedTransactions/NestedTransactions.csproj
@@ -6,12 +6,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Starcounter.Database" Version="3.0.0-rc" />
     <PackageReference Include="Scrutor" Version="3.2.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Starcounter.Database.Extensions\Starcounter.Database.Extensions.csproj" />
-    <ProjectReference Include="..\..\..\Starcounter.Nova\src\Starcounter.Database\Starcounter.Database.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/NestedTransactions/Program.cs
+++ b/samples/NestedTransactions/Program.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Starcounter.Database;
+using Starcounter.Database.Extensions;
+using Starcounter.Database.Linq;
+
+namespace NestedTransactions
+{
+    [Database]
+    public abstract class Person
+    {
+        public abstract string Name { get; set; }
+
+        public abstract Person BestFriend { get; set; }
+    }
+
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            using var services = new ServiceCollection()
+                .AddStarcounter($"Database=./.database/NestedTransactions")
+                .Decorate<ITransactor, NestedTransactor>()
+                .BuildServiceProvider();
+
+            var transactor = services.GetRequiredService<ITransactor>();
+
+            transactor.Transact(db =>
+            {
+                var jane = db.Insert<Person>();
+                jane.Name = "Jane Doe";
+                
+                transactor.Transact(db =>
+                {
+                    // Wihout NestedTransactor, this would not be allowed.
+                    // Starcounter natively don't support nested transactions and
+                    // will raise an exception for any Transact done as part of an
+                    // already running transaction
+
+                    var john = db.Insert<Person>();
+                    john.Name = "John Doe";
+
+                    // Here, we can find "Jane", simply because the NestedTransactor
+                    // execute the current delegate as part of the outer transaction.
+
+                    var jane = db.Sql<Person>("SELECT p FROM Person p WHERE p.Name = ?", "Jane Doe").First();
+                    john.BestFriend = jane;
+
+                    // You can use extension IsNested() if you need to check if the
+                    // current scope is a nested transaction.
+                    
+                    Console.WriteLine(db.IsNested());
+                    Console.WriteLine(john.BestFriend.Name);
+                });
+
+                // This will return false, because we are executing a top-level
+                // transaction.
+                
+                Console.WriteLine(db.IsNested());
+            });
+
+            // Output:
+            // True
+            // Jane Doe
+            // False
+        }
+    }
+}

--- a/samples/NestedTransactions/Program.cs
+++ b/samples/NestedTransactions/Program.cs
@@ -34,15 +34,15 @@ namespace NestedTransactions
                 transactor.Transact(db =>
                 {
                     // Without NestedTransactor, this would not be allowed.
-                    // Starcounter natively don't support nested transactions and
+                    // Starcounter natively does not support nested transactions and
                     // will raise an exception for any Transact done as part of an
-                    // already running transaction
+                    // already running transaction.
 
                     var john = db.Insert<Person>();
                     john.Name = "John Doe";
 
                     // Here, we can find "Jane", simply because the NestedTransactor
-                    // execute the current delegate as part of the outer transaction.
+                    // executes the current delegate as a part of the outer transaction.
 
                     var jane = db.Sql<Person>("SELECT p FROM Person p WHERE p.Name = ?", "Jane Doe").First();
                     john.BestFriend = jane;

--- a/samples/NestedTransactions/Program.cs
+++ b/samples/NestedTransactions/Program.cs
@@ -33,7 +33,7 @@ namespace NestedTransactions
                 
                 transactor.Transact(db =>
                 {
-                    // Wihout NestedTransactor, this would not be allowed.
+                    // Without NestedTransactor, this would not be allowed.
                     // Starcounter natively don't support nested transactions and
                     // will raise an exception for any Transact done as part of an
                     // already running transaction

--- a/samples/NestedTransactions/Program.cs
+++ b/samples/NestedTransactions/Program.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Starcounter.Database;
 using Starcounter.Database.Extensions;
-using Starcounter.Database.Linq;
 
 namespace NestedTransactions
 {
@@ -33,10 +32,8 @@ namespace NestedTransactions
                 
                 transactor.Transact(db =>
                 {
-                    // Without NestedTransactor, this would not be allowed.
-                    // Starcounter natively does not support nested transactions and
-                    // will raise an exception for any Transact done as part of an
-                    // already running transaction.
+                    // Without NestedTransactor, this would execute as a new, independent
+                    // transaction. Now, it instead join the outer one.
 
                     var john = db.Insert<Person>();
                     john.Name = "John Doe";

--- a/samples/README.md
+++ b/samples/README.md
@@ -12,7 +12,7 @@ dotnet run
 ```
 
 ## NestedTransactions
-The [NestedTransactions](./NestedTransactions) sample show how the `NestedTransactor` can be used to extend `Starcounter.Database` to support _nested transactions_, something not natively supported.
+The [NestedTransactions](./NestedTransactions) sample shows how the `NestedTransactor` can be used to extend `Starcounter.Database` to support _nested transactions_, something not natively supported.
 
 See [Program.cs](./NestedTransactions/Program.cs) to see how it looks, or run the sample to see it in action:
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -10,3 +10,13 @@ See [Program.cs](./Hooks/Program.cs) to see how it looks, or run the sample to s
 cd Hooks
 dotnet run
 ```
+
+## NestedTransactions
+The [NestedTransactions](./NestedTransactions) sample show how the `NestedTransactor` can be used to extend `Starcounter.Database` to support _nested transactions_, something not natively supported.
+
+See [Program.cs](./NestedTransactions/Program.cs) to see how it looks, or run the sample to see it in action:
+
+```
+cd NestedTransactions
+dotnet run
+```

--- a/src/Starcounter.Database.Extensions/ContextBase.cs
+++ b/src/Starcounter.Database.Extensions/ContextBase.cs
@@ -16,6 +16,8 @@ namespace Starcounter.Database.Extensions
 
         public virtual IChangeTracker ChangeTracker => _inner.ChangeTracker;
 
+        public virtual ITransaction Transaction => _inner.Transaction;
+
         public virtual void Delete(object obj) => _inner.Delete(obj);
 
         public virtual new bool Equals(object objA, object objB) => _inner.Equals(objA, objB);

--- a/src/Starcounter.Database.Extensions/ContextSponsor.cs
+++ b/src/Starcounter.Database.Extensions/ContextSponsor.cs
@@ -1,0 +1,7 @@
+namespace Starcounter.Database.Extensions
+{
+    public static class ContextSponsor
+    {
+        public static bool IsNested(this IDatabaseContext context) => context is NestedTransactor.NestedTransactionContext;
+    }
+}

--- a/src/Starcounter.Database.Extensions/ContextSponsor.cs
+++ b/src/Starcounter.Database.Extensions/ContextSponsor.cs
@@ -2,6 +2,16 @@ namespace Starcounter.Database.Extensions
 {
     public static class ContextSponsor
     {
-        public static bool IsNested(this IDatabaseContext context) => context is NestedTransactor.NestedTransactionContext;
+        /// <summary>
+        /// Returns a value indicating if the current context represent a
+        /// transaction that is nested within an outer transaction.
+        /// <remarks>
+        /// When using multiple custom transactors, make sure to use the
+        /// <c>NestedTransactor</c> as the most outer one in the decoration
+        /// chain for this method to properly work.
+        /// </remarks>
+        /// </summary>
+        public static bool IsNested(this IDatabaseContext context) 
+            => context is NestedTransactor.NestedTransactionContext;
     }
 }

--- a/src/Starcounter.Database.Extensions/INestedTransactor.cs
+++ b/src/Starcounter.Database.Extensions/INestedTransactor.cs
@@ -1,0 +1,10 @@
+namespace Starcounter.Database.Extensions
+{
+    /// <summary>
+    /// Interface implemented by the <c>NestedTransactor</c> allowing variations
+    /// in it's usage. Specifically, applications can choose to expose nesting
+    /// only in some situation using this interface, by registering using this
+    /// interface rather than decorating <c>ITransactor</c>.
+    /// </summary>
+    public interface INestedTransactor : ITransactor { }
+}

--- a/src/Starcounter.Database.Extensions/NestedTransactor.cs
+++ b/src/Starcounter.Database.Extensions/NestedTransactor.cs
@@ -49,137 +49,143 @@ namespace Starcounter.Database.Extensions
 
         public override T Transact<T>(Func<IDatabaseContext, T> function, TransactOptions options = null)
         {
-            var nested = _current.Value;
-            if (nested != null)
-            {
-                var context = new NestedTransactionContext(nested);
-                try
-                {
-                    return function(context);
-                }
-                catch
-                {
-                    Rollback(context);
-                    throw;
-                }
+            IDatabaseContext nested = _current.Value;
 
+            if (nested == null)
+            {
+                return base.Transact(function, options);
             }
 
-            return base.Transact(function, options);
-        }
+            var context = new NestedTransactionContext(nested);
 
-        public override async Task TransactAsync(Action<IDatabaseContext> action, TransactOptions options = null)
-        {
-            var nested = _current.Value;
-            if (nested != null)
+            try
             {
-                var context = new NestedTransactionContext(nested);
-                try
-                {
-                    action(context);
-                }
-                catch
-                {
-                    Rollback(context);
-                    throw;
-                }
+                return function(context);
             }
-            else
+            catch
             {
-                await base.TransactAsync(action, options);
+                Rollback(context);
+                throw;
             }
         }
 
-        public override async Task<T> TransactAsync<T>(Func<IDatabaseContext, T> function, TransactOptions options = null)
+        public override Task TransactAsync(Action<IDatabaseContext> action, TransactOptions options = null)
         {
-            var nested = _current.Value;
-            if (nested != null)
+            IDatabaseContext nested = _current.Value;
+
+            if (nested == null)
             {
-                var context = new NestedTransactionContext(nested);
-                try
-                {
-                    return function(context);
-                }
-                catch
-                {
-                    Rollback(context);
-                    throw;
-                }
+                return base.TransactAsync(action, options);
             }
-            else
+
+            var context = new NestedTransactionContext(nested);
+
+            try
             {
-                return await base.TransactAsync(function, options);
+                action(context);
+            }
+            catch
+            {
+                Rollback(context);
+                throw;
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public override Task<T> TransactAsync<T>(Func<IDatabaseContext, T> function, TransactOptions options = null)
+        {
+            IDatabaseContext nested = _current.Value;
+
+            if (nested == null)
+            {
+                return base.TransactAsync(function, options);
+            }
+
+            var context = new NestedTransactionContext(nested);
+
+            try
+            {
+                return Task.FromResult(function(context));
+            }
+            catch
+            {
+                Rollback(context);
+                throw;
             }
         }
 
         public override Task TransactAsync(Func<IDatabaseContext, Task> function, TransactOptions options = null)
         {
-            var nested = _current.Value;
-            if (nested != null)
+            IDatabaseContext nested = _current.Value;
+
+            if (nested == null)
             {
-                var context = new NestedTransactionContext(nested);
-                try
-                {
-                    return function(context);
-                }
-                catch
-                {
-                    Rollback(context);
-                    throw;
-                }
+                return base.TransactAsync(function, options);
             }
 
-            return base.TransactAsync(function, options);
+            var context = new NestedTransactionContext(nested);
+
+            try
+            {
+                return function(context);
+            }
+            catch
+            {
+                Rollback(context);
+                throw;
+            }
         }
 
         public override Task<T> TransactAsync<T>(Func<IDatabaseContext, Task<T>> function, TransactOptions options = null)
         {
-            var nested = _current.Value;
-            if (nested != null)
+            IDatabaseContext nested = _current.Value;
+
+            if (nested == null)
             {
-                var context = new NestedTransactionContext(nested);
-                try
-                {
-                    return function(context);
-                }
-                catch
-                {
-                    Rollback(context);
-                    throw;
-                }
+                return base.TransactAsync(function, options);
             }
 
-            return base.TransactAsync(function, options);
+            var context = new NestedTransactionContext(nested);
+
+            try
+            {
+                return function(context);
+            }
+            catch
+            {
+                Rollback(context);
+                throw;
+            }
         }
 
         public override bool TryTransact(Action<IDatabaseContext> action, TransactOptions options = null)
         {
-            var nested = _current.Value;
-            if (nested != null)
+            IDatabaseContext nested = _current.Value;
+
+            if (nested == null)
             {
-                var context = new NestedTransactionContext(nested);
-                try
-                {
-                    action(context);
-                    return true;
-                }
-                catch
-                {
-                    Rollback(context);
-                    throw;
-                }
+                return base.TryTransact(action, options);
             }
 
-            return base.TryTransact(action, options);
+            var context = new NestedTransactionContext(nested);
+
+            try
+            {
+                action(context);
+                return true;
+            }
+            catch
+            {
+                Rollback(context);
+                throw;
+            }
         }
 
         protected override IDatabaseContext EnterContext(IDatabaseContext db) => _current.Value = db;
 
-        protected override void LeaveContext(IDatabaseContext db) { _current.Value = null; }
+        protected override void LeaveContext(IDatabaseContext db) => _current.Value = null;
 
-        protected void Rollback(IDatabaseContext db)
-        {
-            db.Transaction.Rollback();
-        }
+        protected void Rollback(IDatabaseContext db) => db.Transaction.Rollback();
     }
 }

--- a/src/Starcounter.Database.Extensions/NestedTransactor.cs
+++ b/src/Starcounter.Database.Extensions/NestedTransactor.cs
@@ -29,8 +29,17 @@ namespace Starcounter.Database.Extensions
             var nested = _current.Value;
             if (nested != null)
             {
-                action(new NestedTransactionContext(nested));
-                return;
+                var context = new NestedTransactionContext(nested);
+                try
+                {
+                    action(context);
+                    return;
+                }
+                catch
+                {
+                    Rollback(context);
+                    throw;
+                }
             }
 
             base.Transact(action, options);
@@ -41,7 +50,17 @@ namespace Starcounter.Database.Extensions
             var nested = _current.Value;
             if (nested != null)
             {
-                return function(new NestedTransactionContext(nested));
+                var context = new NestedTransactionContext(nested);
+                try
+                {
+                    return function(context);
+                }
+                catch
+                {
+                    Rollback(context);
+                    throw;
+                }
+                
             }
 
             return base.Transact(function, options);
@@ -52,7 +71,16 @@ namespace Starcounter.Database.Extensions
             var nested = _current.Value;
             if (nested != null)
             {
-                action(new NestedTransactionContext(nested));
+                var context = new NestedTransactionContext(nested);
+                try
+                {
+                    action(context);
+                }
+                catch
+                {
+                    Rollback(context);
+                    throw;
+                }
             }
             else
             {
@@ -65,7 +93,16 @@ namespace Starcounter.Database.Extensions
             var nested = _current.Value;
             if (nested != null)
             {
-                return function(new NestedTransactionContext(nested));
+                var context = new NestedTransactionContext(nested);
+                try
+                {
+                    return function(context);
+                }
+                catch
+                {
+                    Rollback(context);
+                    throw;
+                }
             }
             else
             {
@@ -78,7 +115,16 @@ namespace Starcounter.Database.Extensions
             var nested = _current.Value;
             if (nested != null)
             {
-                return function(new NestedTransactionContext(nested));
+                var context = new NestedTransactionContext(nested);
+                try
+                {
+                    return function(context);
+                }
+                catch
+                {
+                    Rollback(context);
+                    throw;
+                }
             }
 
             return base.TransactAsync(function, options);
@@ -89,7 +135,16 @@ namespace Starcounter.Database.Extensions
             var nested = _current.Value;
             if (nested != null)
             {
-                return function(new NestedTransactionContext(nested));
+                var context = new NestedTransactionContext(nested);
+                try
+                {
+                    return function(context);
+                }
+                catch
+                {
+                    Rollback(context);
+                    throw;
+                }
             }
 
             return base.TransactAsync(function, options);
@@ -100,8 +155,17 @@ namespace Starcounter.Database.Extensions
             var nested = _current.Value;
             if (nested != null)
             {
-                action(new NestedTransactionContext(nested));
-                return true;
+                var context = new NestedTransactionContext(nested);
+                try
+                {
+                    action(context);
+                    return true;
+                }
+                catch
+                {
+                    Rollback(context);
+                    throw;
+                }
             }
 
             return base.TryTransact(action, options);
@@ -110,5 +174,10 @@ namespace Starcounter.Database.Extensions
         protected override IDatabaseContext EnterContext(IDatabaseContext db) => _current.Value = db;
 
         protected override void LeaveContext(IDatabaseContext db) { _current.Value = null; }
+
+        protected void Rollback(IDatabaseContext db)
+        {
+            // TODO:
+        }
     }
 }

--- a/src/Starcounter.Database.Extensions/NestedTransactor.cs
+++ b/src/Starcounter.Database.Extensions/NestedTransactor.cs
@@ -60,7 +60,7 @@ namespace Starcounter.Database.Extensions
                     Rollback(context);
                     throw;
                 }
-                
+
             }
 
             return base.Transact(function, options);

--- a/src/Starcounter.Database.Extensions/NestedTransactor.cs
+++ b/src/Starcounter.Database.Extensions/NestedTransactor.cs
@@ -84,10 +84,10 @@ namespace Starcounter.Database.Extensions
             {
                 action(context);
             }
-            catch
+            catch (Exception e)
             {
                 Rollback(context);
-                throw;
+                return Task.FromException(e);
             }
 
             return Task.CompletedTask;
@@ -108,10 +108,10 @@ namespace Starcounter.Database.Extensions
             {
                 return Task.FromResult(function(context));
             }
-            catch
+            catch (Exception e)
             {
                 Rollback(context);
-                throw;
+                return Task.FromException<T>(e);
             }
         }
 
@@ -130,10 +130,10 @@ namespace Starcounter.Database.Extensions
             {
                 return function(context);
             }
-            catch
+            catch (Exception e)
             {
                 Rollback(context);
-                throw;
+                return Task.FromException(e);
             }
         }
 
@@ -152,10 +152,10 @@ namespace Starcounter.Database.Extensions
             {
                 return function(context);
             }
-            catch
+            catch (Exception e)
             {
                 Rollback(context);
-                throw;
+                return Task.FromException<T>(e);
             }
         }
 

--- a/src/Starcounter.Database.Extensions/NestedTransactor.cs
+++ b/src/Starcounter.Database.Extensions/NestedTransactor.cs
@@ -177,7 +177,7 @@ namespace Starcounter.Database.Extensions
 
         protected void Rollback(IDatabaseContext db)
         {
-            // TODO:
+            db.Transaction.Rollback();
         }
     }
 }

--- a/src/Starcounter.Database.Extensions/NestedTransactor.cs
+++ b/src/Starcounter.Database.Extensions/NestedTransactor.cs
@@ -69,7 +69,7 @@ namespace Starcounter.Database.Extensions
             {
                 return function(new NestedTransactionContext(nested));
             }
-            
+
             return base.TransactAsync(function, options);
         }
 
@@ -80,7 +80,7 @@ namespace Starcounter.Database.Extensions
             {
                 return function(new NestedTransactionContext(nested));
             }
-            
+
             return base.TransactAsync(function, options);
         }
 
@@ -92,7 +92,7 @@ namespace Starcounter.Database.Extensions
                 action(new NestedTransactionContext(nested));
                 return true;
             }
-            
+
             return base.TryTransact(action, options);
         }
 

--- a/src/Starcounter.Database.Extensions/NestedTransactor.cs
+++ b/src/Starcounter.Database.Extensions/NestedTransactor.cs
@@ -52,8 +52,15 @@ namespace Starcounter.Database.Extensions
             var nested = _current.Value;
             if (nested != null)
             {
-                action(new NestedTransactionContext(nested));
-                return Task.CompletedTask;
+                try
+                {
+                    action(new NestedTransactionContext(nested));
+                    return Task.CompletedTask;
+                }
+                catch (Exception e)
+                {
+                    return Task.FromException(e);
+                }
             }
 
             return base.TransactAsync(action, options);
@@ -64,8 +71,15 @@ namespace Starcounter.Database.Extensions
             var nested = _current.Value;
             if (nested != null)
             {
-                T result = function(new NestedTransactionContext(nested));
-                return Task.FromResult(result);
+                try
+                {
+                    T result = function(new NestedTransactionContext(nested));
+                    return Task.FromResult(result);
+                }
+                catch (Exception e)
+                {
+                    return Task.FromException<T>(e);
+                }
             }
 
             return base.TransactAsync(function, options);

--- a/src/Starcounter.Database.Extensions/NestedTransactor.cs
+++ b/src/Starcounter.Database.Extensions/NestedTransactor.cs
@@ -129,7 +129,6 @@ namespace Starcounter.Database.Extensions
                 try
                 {
                     await function(context);
-                    return;
                 }
                 catch
                 {

--- a/src/Starcounter.Database.Extensions/NestedTransactor.cs
+++ b/src/Starcounter.Database.Extensions/NestedTransactor.cs
@@ -15,7 +15,7 @@ namespace Starcounter.Database.Extensions
     /// </summary>
     public class NestedTransactor : TransactorBase
     {
-        ThreadLocal<IDatabaseContext> _current = new ThreadLocal<IDatabaseContext>();
+        AsyncLocal<IDatabaseContext> _current = new AsyncLocal<IDatabaseContext>();
 
         internal class NestedTransactionContext : ContextBase
         {

--- a/src/Starcounter.Database.Extensions/NestedTransactor.cs
+++ b/src/Starcounter.Database.Extensions/NestedTransactor.cs
@@ -13,7 +13,7 @@ namespace Starcounter.Database.Extensions
     /// <c>NestedTransactor</c> as the most outer one in the decoration chain. 
     /// </remarks>
     /// </summary>
-    public class NestedTransactor : TransactorBase
+    public class NestedTransactor : TransactorBase, INestedTransactor
     {
         AsyncLocal<IDatabaseContext> _current = new AsyncLocal<IDatabaseContext>();
 

--- a/src/Starcounter.Database.Extensions/NestedTransactor.cs
+++ b/src/Starcounter.Database.Extensions/NestedTransactor.cs
@@ -6,10 +6,10 @@ namespace Starcounter.Database.Extensions
 {
     /// <summary>
     /// Custom transactor that allow nesting of transactions, and running the
-    /// given delegate as part of an other transaction, if given to a Transact
+    /// given delegate as a part of an other transaction, if given to a Transact
     /// call within an already executing transaction.
     /// <remarks>
-    /// When using multiple custom transactors, its recommended to use the
+    /// When using multiple custom transactors, it is recommended to use the
     /// <c>NestedTransactor</c> as the most outer one in the decoration chain. 
     /// </remarks>
     /// </summary>

--- a/src/Starcounter.Database.Extensions/NestedTransactor.cs
+++ b/src/Starcounter.Database.Extensions/NestedTransactor.cs
@@ -4,6 +4,15 @@ using System.Threading.Tasks;
 
 namespace Starcounter.Database.Extensions
 {
+    /// <summary>
+    /// Custom transactor that allow nesting of transactions, and running the
+    /// given delegate as part of an other transaction, if given to a Transact
+    /// call within an already executing transaction.
+    /// <remarks>
+    /// When using multiple custom transactors, its recommended to use the
+    /// <c>NestedTransactor</c> as the most outer one in the decoration chain. 
+    /// </remarks>
+    /// </summary>
     public class NestedTransactor : TransactorBase
     {
         ThreadLocal<IDatabaseContext> _current = new ThreadLocal<IDatabaseContext>();

--- a/src/Starcounter.Database.Extensions/NestedTransactor.cs
+++ b/src/Starcounter.Database.Extensions/NestedTransactor.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Starcounter.Database.Extensions
+{
+    public class NestedTransactor : TransactorBase
+    {
+        ThreadLocal<IDatabaseContext> _current = new ThreadLocal<IDatabaseContext>();
+
+        internal class NestedTransactionContext : ContextBase
+        {
+            public NestedTransactionContext(IDatabaseContext inner) : base(inner) { }
+        }
+
+        public NestedTransactor(ITransactor innerTransactor) : base(innerTransactor) { }
+
+        public override void Transact(Action<IDatabaseContext> action, TransactOptions options = null)
+        {
+            var nested = _current.Value;
+            if (nested != null)
+            {
+                action(new NestedTransactionContext(nested));
+                return;
+            }
+
+            base.Transact(action, options);
+        }
+
+        public override T Transact<T>(Func<IDatabaseContext, T> function, TransactOptions options = null)
+        {
+            var nested = _current.Value;
+            if (nested != null)
+            {
+                return function(new NestedTransactionContext(nested));
+            }
+
+            return base.Transact(function, options);
+        }
+
+        public override Task TransactAsync(Action<IDatabaseContext> action, TransactOptions options = null)
+        {
+            var nested = _current.Value;
+            if (nested != null)
+            {
+                action(new NestedTransactionContext(nested));
+                return Task.CompletedTask;
+            }
+
+            return base.TransactAsync(action, options);
+        }
+
+        public override Task<T> TransactAsync<T>(Func<IDatabaseContext, T> function, TransactOptions options = null)
+        {
+            var nested = _current.Value;
+            if (nested != null)
+            {
+                T result = function(new NestedTransactionContext(nested));
+                return Task.FromResult(result);
+            }
+
+            return base.TransactAsync(function, options);
+        }
+
+        public override Task TransactAsync(Func<IDatabaseContext, Task> function, TransactOptions options = null)
+        {
+            var nested = _current.Value;
+            if (nested != null)
+            {
+                return function(new NestedTransactionContext(nested));
+            }
+            
+            return base.TransactAsync(function, options);
+        }
+
+        public override Task<T> TransactAsync<T>(Func<IDatabaseContext, Task<T>> function, TransactOptions options = null)
+        {
+            var nested = _current.Value;
+            if (nested != null)
+            {
+                return function(new NestedTransactionContext(nested));
+            }
+            
+            return base.TransactAsync(function, options);
+        }
+
+        public override bool TryTransact(Action<IDatabaseContext> action, TransactOptions options = null)
+        {
+            var nested = _current.Value;
+            if (nested != null)
+            {
+                action(new NestedTransactionContext(nested));
+                return true;
+            }
+            
+            return base.TryTransact(action, options);
+        }
+
+        protected override IDatabaseContext EnterContext(IDatabaseContext db) => _current.Value = db;
+
+        protected override void LeaveContext(IDatabaseContext db) { _current.Value = null; }
+    }
+}

--- a/src/Starcounter.Database.Extensions/NestedTransactor.cs
+++ b/src/Starcounter.Database.Extensions/NestedTransactor.cs
@@ -47,42 +47,30 @@ namespace Starcounter.Database.Extensions
             return base.Transact(function, options);
         }
 
-        public override Task TransactAsync(Action<IDatabaseContext> action, TransactOptions options = null)
+        public override async Task TransactAsync(Action<IDatabaseContext> action, TransactOptions options = null)
         {
             var nested = _current.Value;
             if (nested != null)
             {
-                try
-                {
-                    action(new NestedTransactionContext(nested));
-                    return Task.CompletedTask;
-                }
-                catch (Exception e)
-                {
-                    return Task.FromException(e);
-                }
+                action(new NestedTransactionContext(nested));
             }
-
-            return base.TransactAsync(action, options);
+            else
+            {
+                await base.TransactAsync(action, options);
+            }
         }
 
-        public override Task<T> TransactAsync<T>(Func<IDatabaseContext, T> function, TransactOptions options = null)
+        public override async Task<T> TransactAsync<T>(Func<IDatabaseContext, T> function, TransactOptions options = null)
         {
             var nested = _current.Value;
             if (nested != null)
             {
-                try
-                {
-                    T result = function(new NestedTransactionContext(nested));
-                    return Task.FromResult(result);
-                }
-                catch (Exception e)
-                {
-                    return Task.FromException<T>(e);
-                }
+                return function(new NestedTransactionContext(nested));
             }
-
-            return base.TransactAsync(function, options);
+            else
+            {
+                return await base.TransactAsync(function, options);
+            }
         }
 
         public override Task TransactAsync(Func<IDatabaseContext, Task> function, TransactOptions options = null)

--- a/src/Starcounter.Database.Extensions/Starcounter.Database.Extensions.csproj
+++ b/src/Starcounter.Database.Extensions/Starcounter.Database.Extensions.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.2" />
-    <PackageReference Include="Starcounter.Database.Abstractions" Version="3.0.0-rc" />
+    <PackageReference Include="Starcounter.Database.Abstractions" Version="3.0.0-rc-*" />
   </ItemGroup>
   
 </Project>

--- a/src/Starcounter.Database.Extensions/Starcounter.Database.Extensions.csproj
+++ b/src/Starcounter.Database.Extensions/Starcounter.Database.Extensions.csproj
@@ -6,10 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.2" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\Starcounter.Nova\src\Starcounter.Database.Abstractions\Starcounter.Database.Abstractions.csproj" />
+    <PackageReference Include="Starcounter.Database.Abstractions" Version="3.0.0-rc" />
   </ItemGroup>
   
 </Project>

--- a/src/Starcounter.Database.Extensions/Starcounter.Database.Extensions.csproj
+++ b/src/Starcounter.Database.Extensions/Starcounter.Database.Extensions.csproj
@@ -6,7 +6,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.2" />
-    <PackageReference Include="Starcounter.Database.Abstractions" Version="3.0.0-rc" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Starcounter.Nova\src\Starcounter.Database.Abstractions\Starcounter.Database.Abstractions.csproj" />
   </ItemGroup>
   
 </Project>

--- a/test/Starcounter.Database.Extensions.IntegrationTests/DatabaseExtensionsIntegrationTestContext.cs
+++ b/test/Starcounter.Database.Extensions.IntegrationTests/DatabaseExtensionsIntegrationTestContext.cs
@@ -1,11 +1,11 @@
 using System;
 using System.Collections.Generic;
-using TestUtilities;
+using Starcounter.Database.TestResources;
 using Xunit;
 
 namespace Starcounter.Database.Extensions.IntegrationTests
 {
-    public class DatabaseExtensionsIntegrationTestContext : TestAppHost
+    public class DatabaseExtensionsIntegrationTestContext : TemporaryDatabase
     {
         public DatabaseExtensionsIntegrationTestContext() : base() { }
 

--- a/test/Starcounter.Database.Extensions.IntegrationTests/DatabaseExtensionsIntegrationTestContext.cs
+++ b/test/Starcounter.Database.Extensions.IntegrationTests/DatabaseExtensionsIntegrationTestContext.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using TestUtilities;
+using Xunit;
+
+namespace Starcounter.Database.Extensions.IntegrationTests
+{
+    public class DatabaseExtensionsIntegrationTestContext : TestAppHost
+    {
+        public DatabaseExtensionsIntegrationTestContext() : base() { }
+
+        protected override IEnumerable<Type> ProvideDatabaseTypes() => typeof(DatabaseExtensionsIntegrationTestContext).Assembly.ExportedTypes;
+    }
+
+    [CollectionDefinition(nameof(DatabaseExtensionsIntegrationTestContext))]
+    public class DatabaseCollection : ICollectionFixture<DatabaseExtensionsIntegrationTestContext> { }
+}

--- a/test/Starcounter.Database.Extensions.IntegrationTests/DbContext.cs
+++ b/test/Starcounter.Database.Extensions.IntegrationTests/DbContext.cs
@@ -53,6 +53,15 @@ namespace Starcounter.Database.Extensions.IntegrationTests
 
         public IChangeTracker ChangeTracker => new DbContextChangeTracker(_changes);
 
+        class TransactionImpl : ITransaction
+        {
+            // TODO: If we decide to keep this, clear _changes after first reverting
+            // each from underlying Storage too.
+            public void Rollback() => throw new NotImplementedException();
+        }
+
+        public ITransaction Transaction => new TransactionImpl();
+
         public void Delete(object obj)
         {
             var id = _storage.Delete(obj);

--- a/test/Starcounter.Database.Extensions.IntegrationTests/DbContext.cs
+++ b/test/Starcounter.Database.Extensions.IntegrationTests/DbContext.cs
@@ -6,7 +6,7 @@ using Starcounter.Database.ChangeTracking;
 
 namespace Starcounter.Database.Extensions.IntegrationTests
 {
-    class DbContext : IDatabaseContext
+    class DbContext : IDatabaseContext, IDisposable
     {
         readonly Dictionary<ulong, Tuple<object, ChangeType>> _changes
             = new Dictionary<ulong, Tuple<object, ChangeType>>();
@@ -14,6 +14,8 @@ namespace Starcounter.Database.Extensions.IntegrationTests
         readonly DbStorage _storage;
 
         readonly DbProxyTypeGenerator _proxyTypeGenerator;
+
+        internal Action<IDatabaseContext> DisposeCallback { get; set; }
 
         public DbContext(DbStorage storage, DbProxyTypeGenerator proxyTypeGenerator)
         {
@@ -84,5 +86,7 @@ namespace Starcounter.Database.Extensions.IntegrationTests
         }
 
         public ISqlResult<T> Sql<T>(string query, params object[] values) => throw new NotImplementedException();
+
+        public void Dispose() => DisposeCallback?.Invoke(this);
     }
 }

--- a/test/Starcounter.Database.Extensions.IntegrationTests/DbCoreTests.cs
+++ b/test/Starcounter.Database.Extensions.IntegrationTests/DbCoreTests.cs
@@ -8,7 +8,7 @@ namespace Starcounter.Database.Extensions.IntegrationTests
 {
     public class DbCoreTests : ServicedTests
     {
-        public DbCoreTests(DatabaseExtensionsIntegrationTestContext context) : base(context) {}
+        public DbCoreTests(DatabaseExtensionsIntegrationTestContext context) : base(context) { }
 
         public class Person { }
 

--- a/test/Starcounter.Database.Extensions.IntegrationTests/DbCoreTests.cs
+++ b/test/Starcounter.Database.Extensions.IntegrationTests/DbCoreTests.cs
@@ -8,12 +8,14 @@ namespace Starcounter.Database.Extensions.IntegrationTests
 {
     public class DbCoreTests : ServicedTests
     {
+        public DbCoreTests(DatabaseExtensionsIntegrationTestContext context) : base(context) {}
+
         public class Person { }
 
         [Fact]
         public void ServiceSetupYieldExpectedImplementations()
         {
-            var transactor = CreateServices().GetRequiredService<ITransactor>();
+            var transactor = CreateServices(withRealTemporaryDatabase: false).GetRequiredService<ITransactor>();
             var context = transactor.Transact(db => db);
 
             Assert.IsType<DbTransactor>(transactor);
@@ -23,7 +25,7 @@ namespace Starcounter.Database.Extensions.IntegrationTests
         [Fact]
         public void InsertOneReturnFirstId()
         {
-            var t = CreateServices().GetRequiredService<ITransactor>();
+            var t = CreateServices(withRealTemporaryDatabase: false).GetRequiredService<ITransactor>();
 
             t.Transact(db =>
             {
@@ -35,7 +37,7 @@ namespace Starcounter.Database.Extensions.IntegrationTests
         [Fact]
         public void InsertOneReturnExpectedChanges()
         {
-            var t = CreateServices().GetRequiredService<ITransactor>();
+            var t = CreateServices(withRealTemporaryDatabase: false).GetRequiredService<ITransactor>();
 
             t.Transact(db =>
             {
@@ -50,7 +52,7 @@ namespace Starcounter.Database.Extensions.IntegrationTests
         [Fact]
         public void DeleteResultInObjectBeingRemoved()
         {
-            var t = CreateServices().GetRequiredService<ITransactor>();
+            var t = CreateServices(withRealTemporaryDatabase: false).GetRequiredService<ITransactor>();
 
             var id = t.Transact(db =>
             {
@@ -70,7 +72,7 @@ namespace Starcounter.Database.Extensions.IntegrationTests
         [Fact]
         public void InsertThenDeleteResultInNoChanges()
         {
-            var t = CreateServices().GetRequiredService<ITransactor>();
+            var t = CreateServices(withRealTemporaryDatabase: false).GetRequiredService<ITransactor>();
 
             var changes = t.Transact(db =>
             {
@@ -86,7 +88,7 @@ namespace Starcounter.Database.Extensions.IntegrationTests
         [Fact]
         public void CoreTransactorDontAllowNesting()
         {
-            var t = CreateServices().GetRequiredService<ITransactor>();
+            var t = CreateServices(withRealTemporaryDatabase: false).GetRequiredService<ITransactor>();
 
             Action transact = () => t.Transact(_ => t.Transact(__ => { }));
             Func<object> transactFunc = () => t.Transact(_ => t.Transact(__ => new object()));

--- a/test/Starcounter.Database.Extensions.IntegrationTests/DbCoreTests.cs
+++ b/test/Starcounter.Database.Extensions.IntegrationTests/DbCoreTests.cs
@@ -98,5 +98,31 @@ namespace Starcounter.Database.Extensions.IntegrationTests
             Assert.Throws<InvalidOperationException>(tryTransact);
             Assert.ThrowsAsync<InvalidOperationException>(transactAsync);
         }
+
+        [Fact]
+        public void TransactAsyncFailingActionRenderFaultyTask()
+        {
+            var transactor = CreateServices().GetRequiredService<ITransactor>();
+
+            Action<IDatabaseContext> action = db => throw new Exception("Foo");
+
+            var t = transactor.TransactAsync(action);
+
+            var e = Assert.Throws<Exception>(() => t.GetAwaiter().GetResult());
+            Assert.Equal("Foo", e.Message);
+        }
+
+        [Fact]
+        public void TransactAsyncFailingFuncRenderFaultyTask()
+        {
+            var transactor = CreateServices().GetRequiredService<ITransactor>();
+
+            Func<IDatabaseContext, bool> func = db => throw new Exception("Foo");
+
+            var t = transactor.TransactAsync(func);
+
+            var e = Assert.Throws<Exception>(() => t.GetAwaiter().GetResult());
+            Assert.Equal("Foo", e.Message);
+        }
     }
 }

--- a/test/Starcounter.Database.Extensions.IntegrationTests/DbCoreTests.cs
+++ b/test/Starcounter.Database.Extensions.IntegrationTests/DbCoreTests.cs
@@ -86,7 +86,7 @@ namespace Starcounter.Database.Extensions.IntegrationTests
         }
 
         [Fact]
-        public void CoreTransactorDontAllowNesting()
+        public async Task CoreTransactorDontAllowNesting()
         {
             var t = CreateServices(withRealTemporaryDatabase: false).GetRequiredService<ITransactor>();
 
@@ -98,11 +98,11 @@ namespace Starcounter.Database.Extensions.IntegrationTests
             Assert.Throws<InvalidOperationException>(transact);
             Assert.Throws<InvalidOperationException>(transactFunc);
             Assert.Throws<InvalidOperationException>(tryTransact);
-            Assert.ThrowsAsync<InvalidOperationException>(transactAsync);
+            await Assert.ThrowsAsync<InvalidOperationException>(transactAsync);
         }
 
         [Fact]
-        public void TransactAsyncFailingActionRenderFaultyTask()
+        public async Task TransactAsyncFailingActionRenderFaultyTask()
         {
             var transactor = CreateServices().GetRequiredService<ITransactor>();
 
@@ -110,12 +110,19 @@ namespace Starcounter.Database.Extensions.IntegrationTests
 
             var t = transactor.TransactAsync(action);
 
-            var e = Assert.Throws<Exception>(() => t.GetAwaiter().GetResult());
-            Assert.Equal("Foo", e.Message);
+            {
+                var e = Assert.Throws<Exception>(() => t.GetAwaiter().GetResult());
+                Assert.Equal("Foo", e.Message);
+            }
+
+            {
+                var e = await Assert.ThrowsAsync<Exception>(() => t);
+                Assert.Equal("Foo", e.Message);
+            }
         }
 
         [Fact]
-        public void TransactAsyncFailingFuncRenderFaultyTask()
+        public async Task TransactAsyncFailingFuncRenderFaultyTask()
         {
             var transactor = CreateServices().GetRequiredService<ITransactor>();
 
@@ -123,8 +130,15 @@ namespace Starcounter.Database.Extensions.IntegrationTests
 
             var t = transactor.TransactAsync(func);
 
-            var e = Assert.Throws<Exception>(() => t.GetAwaiter().GetResult());
-            Assert.Equal("Foo", e.Message);
+            {
+                var e = Assert.Throws<Exception>(() => t.GetAwaiter().GetResult());
+                Assert.Equal("Foo", e.Message);
+            }
+
+            {
+                var e = await Assert.ThrowsAsync<Exception>(() => t);
+                Assert.Equal("Foo", e.Message);
+            }
         }
     }
 }

--- a/test/Starcounter.Database.Extensions.IntegrationTests/DbTransactor.cs
+++ b/test/Starcounter.Database.Extensions.IntegrationTests/DbTransactor.cs
@@ -78,14 +78,14 @@ namespace Starcounter.Database.Extensions.IntegrationTests
             catch (InvalidOperationException e) when (e.InnerException is AlreadyExecutingException)
             {
                 throw;
-            } 
+            }
             catch
             {
                 return false;
             }
         }
 
-        class AlreadyExecutingException : Exception {}
+        class AlreadyExecutingException : Exception { }
 
         void ThrowIfAlreadyExecuting()
         {

--- a/test/Starcounter.Database.Extensions.IntegrationTests/DbTransactor.cs
+++ b/test/Starcounter.Database.Extensions.IntegrationTests/DbTransactor.cs
@@ -30,8 +30,15 @@ namespace Starcounter.Database.Extensions.IntegrationTests
         public Task TransactAsync(Action<IDatabaseContext> action, TransactOptions options = null)
         {
             using var context = CreateContext();
-            action(context);
-            return Task.CompletedTask;
+            try
+            {
+                action(context);
+                return Task.CompletedTask;
+            }
+            catch (Exception e)
+            {
+                return Task.FromException(e);
+            }
         }
 
         public Task TransactAsync(Func<IDatabaseContext, Task> function, TransactOptions options = null)
@@ -43,8 +50,15 @@ namespace Starcounter.Database.Extensions.IntegrationTests
         public Task<T> TransactAsync<T>(Func<IDatabaseContext, T> function, TransactOptions options = null)
         {
             using var context = CreateContext();
-            var obj = function(context);
-            return Task<T>.FromResult(default(T));
+            try
+            {
+                var obj = function(context);
+                return Task<T>.FromResult(obj);
+            }
+            catch (Exception e)
+            {
+                return Task.FromException<T>(e);
+            }
         }
 
         public Task<T> TransactAsync<T>(Func<IDatabaseContext, Task<T>> function, TransactOptions options = null)

--- a/test/Starcounter.Database.Extensions.IntegrationTests/MultilevelTransactorDecorationTests.cs
+++ b/test/Starcounter.Database.Extensions.IntegrationTests/MultilevelTransactorDecorationTests.cs
@@ -224,7 +224,7 @@ namespace Starcounter.Database.Extensions.IntegrationTests
 
             foreach (var transactor in transactors)
             {
-                (ulong Id, bool WasHooked) result = transactor.Transact(db =>
+                (ulong Id, bool WasHooked) resultFirst = transactor.Transact(db =>
                 {
                     var p = db.Insert<Person>();
                     var id = db.GetOid(p);
@@ -246,15 +246,16 @@ namespace Starcounter.Database.Extensions.IntegrationTests
                     return (id, p.WasHooked);
                 });
 
-                var wasDeleted = transactor.Transact(db =>
+                (bool WasDeleted, bool WasHooked) resultSecond = transactor.Transact(db =>
                 {
-                    var p = db.Get<Person>(result.Id);
+                    var p = db.Get<Person>(resultFirst.Id);
                     db.Delete(p);
-                    return p.WasDeleted;
+                    return (p.WasDeleted, p.WasHooked);
                 });
 
-                Assert.True(result.WasHooked);
-                Assert.True(wasDeleted);
+                Assert.False(resultFirst.WasHooked);
+                Assert.True(resultSecond.WasHooked);
+                Assert.True(resultSecond.WasDeleted);
             }
         }
     }

--- a/test/Starcounter.Database.Extensions.IntegrationTests/MultilevelTransactorDecorationTests.cs
+++ b/test/Starcounter.Database.Extensions.IntegrationTests/MultilevelTransactorDecorationTests.cs
@@ -214,9 +214,6 @@ namespace Starcounter.Database.Extensions.IntegrationTests
 
             var transactors = new List<ITransactor>(new[]
             {
-                CreateTransactorForCombination<NestedTransactor, OnDeleteTransactor, PreCommitTransactor>(),
-                CreateTransactorForCombination<NestedTransactor, PreCommitTransactor, OnDeleteTransactor>(),
-                CreateTransactorForCombination<OnDeleteTransactor, NestedTransactor, PreCommitTransactor>(),
                 CreateTransactorForCombination<OnDeleteTransactor, PreCommitTransactor, NestedTransactor>(),
                 CreateTransactorForCombination<PreCommitTransactor, OnDeleteTransactor, NestedTransactor>(),
                 CreateTransactorForCombination<PreCommitTransactor, NestedTransactor, OnDeleteTransactor>()

--- a/test/Starcounter.Database.Extensions.IntegrationTests/MultilevelTransactorDecorationTests.cs
+++ b/test/Starcounter.Database.Extensions.IntegrationTests/MultilevelTransactorDecorationTests.cs
@@ -9,7 +9,7 @@ namespace Starcounter.Database.Extensions.IntegrationTests
 {
     public sealed class MultilevelTransactorDecorationTests : ServicedTests
     {
-        public MultilevelTransactorDecorationTests(DatabaseExtensionsIntegrationTestContext context) : base(context) {}
+        public MultilevelTransactorDecorationTests(DatabaseExtensionsIntegrationTestContext context) : base(context) { }
 
         [Database]
         public abstract class Person : IDeleteAware
@@ -18,7 +18,7 @@ namespace Starcounter.Database.Extensions.IntegrationTests
             Action<Person> _whenDeleted;
 
             public void WhenDeleted(Action<Person> action) => _whenDeleted = action;
-            
+
             public void OnDelete(IDatabaseContext db) => _whenDeleted?.Invoke(this);
         }
 
@@ -37,12 +37,12 @@ namespace Starcounter.Database.Extensions.IntegrationTests
             var result = transactor.Transact(db =>
             {
                 var p = db.Insert<Person>();
-                
+
                 var deleted = false;
                 p.WhenDeleted(p => deleted = true);
 
                 db.Delete(p);
-                
+
                 return deleted;
             });
 
@@ -65,7 +65,7 @@ namespace Starcounter.Database.Extensions.IntegrationTests
             var result = transactor.Transact(db =>
             {
                 var p = db.Insert<Person>();
-                
+
                 var deleted = false;
                 p.WhenDeleted(p => deleted = true);
 
@@ -165,7 +165,7 @@ namespace Starcounter.Database.Extensions.IntegrationTests
             var wasDeleted = transactor.Transact(db =>
             {
                 var p = db.Get<Person>(id);
-                
+
                 var deleted = false;
                 p.WhenDeleted(p => deleted = true);
 
@@ -206,7 +206,7 @@ namespace Starcounter.Database.Extensions.IntegrationTests
             var wasDeleted = transactor.Transact(db =>
             {
                 var p = db.Get<Person>(id);
-                
+
                 var deleted = false;
                 p.WhenDeleted(p => deleted = true);
 
@@ -267,7 +267,7 @@ namespace Starcounter.Database.Extensions.IntegrationTests
             (bool WasDeleted, bool WasHooked) resultSecond = transactor.Transact(db =>
             {
                 var p = db.Get<Person>(resultFirst.Id);
-                
+
                 var deleted = false;
                 p.WhenDeleted(p => deleted = true);
                 db.Delete(p);

--- a/test/Starcounter.Database.Extensions.IntegrationTests/NestedTransactorTests.cs
+++ b/test/Starcounter.Database.Extensions.IntegrationTests/NestedTransactorTests.cs
@@ -7,6 +7,8 @@ namespace Starcounter.Database.Extensions.IntegrationTests
 {
     public sealed class NestedTransactorTests : ServicedTests
     {
+        public NestedTransactorTests(DatabaseExtensionsIntegrationTestContext context) : base(context) {}
+
         [Fact]
         public void AllowNestedTransaction()
         {

--- a/test/Starcounter.Database.Extensions.IntegrationTests/NestedTransactorTests.cs
+++ b/test/Starcounter.Database.Extensions.IntegrationTests/NestedTransactorTests.cs
@@ -7,9 +7,9 @@ namespace Starcounter.Database.Extensions.IntegrationTests
 {
     public sealed class NestedTransactorTests : ServicedTests
     {
-        [Database] public class Person {}
+        [Database] public class Person { }
 
-        public NestedTransactorTests(DatabaseExtensionsIntegrationTestContext context) : base(context) {}
+        public NestedTransactorTests(DatabaseExtensionsIntegrationTestContext context) : base(context) { }
 
         [Fact]
         public void AllowNestedTransaction()
@@ -139,7 +139,7 @@ namespace Starcounter.Database.Extensions.IntegrationTests
                 s => s.Decorate<ITransactor, NestedTransactor>())
                 .GetRequiredService<ITransactor>();
 
-            Func<IDatabaseContext, bool> func = db => 
+            Func<IDatabaseContext, bool> func = db =>
             {
                 if (db.IsNested())
                 {

--- a/test/Starcounter.Database.Extensions.IntegrationTests/NestedTransactorTests.cs
+++ b/test/Starcounter.Database.Extensions.IntegrationTests/NestedTransactorTests.cs
@@ -89,7 +89,7 @@ namespace Starcounter.Database.Extensions.IntegrationTests
         }
 
         [Fact]
-        public void ShouldRenderContextThatIndicatesNestingWhenRunningContinuation()
+        public async Task ShouldRenderContextThatIndicatesNestingWhenRunningContinuation()
         {
             var transactor = CreateServices(
                 s => s.Decorate<ITransactor, NestedTransactor>())
@@ -108,11 +108,12 @@ namespace Starcounter.Database.Extensions.IntegrationTests
                 return transactor.Transact(db => db.IsNested());
             });
 
-            Assert.True(t.GetAwaiter().GetResult());
+            var result = await t;
+            Assert.True(result);
         }
 
         [Fact]
-        public void NestedTransactAsyncFailingActionRenderFaultyTask()
+        public async Task NestedTransactAsyncFailingActionRenderFaultyTask()
         {
             var transactor = CreateServices(
                 s => s.Decorate<ITransactor, NestedTransactor>())
@@ -128,12 +129,12 @@ namespace Starcounter.Database.Extensions.IntegrationTests
 
             var t = transactor.TransactAsync(db => transactor.TransactAsync(action));
 
-            var e = Assert.Throws<Exception>(() => t.GetAwaiter().GetResult());
+            var e = await Assert.ThrowsAsync<Exception>(() => t);
             Assert.Equal("Foo", e.Message);
         }
 
         [Fact]
-        public void NestedTransactAsyncFailingFuncRenderFaultyTask()
+        public async Task NestedTransactAsyncFailingFuncRenderFaultyTask()
         {
             var transactor = CreateServices(
                 s => s.Decorate<ITransactor, NestedTransactor>())
@@ -151,7 +152,7 @@ namespace Starcounter.Database.Extensions.IntegrationTests
 
             var t = transactor.TransactAsync(db => transactor.TransactAsync(func));
 
-            var e = Assert.Throws<Exception>(() => t.GetAwaiter().GetResult());
+            var e = await Assert.ThrowsAsync<Exception>(() => t);
             Assert.Equal("Foo", e.Message);
         }
     }

--- a/test/Starcounter.Database.Extensions.IntegrationTests/NestedTransactorTests.cs
+++ b/test/Starcounter.Database.Extensions.IntegrationTests/NestedTransactorTests.cs
@@ -43,7 +43,7 @@ namespace Starcounter.Database.Extensions.IntegrationTests
 
             // This execute as a top-level transaction, saving the context as
             // a thread local.
-            var t = transactor.Transact(async db =>
+            var t = transactor.TransactAsync(async db =>
             {
                 // Yield to force continuation to be scheduled and
                 // hence assure we test actual asynchronous execution.

--- a/test/Starcounter.Database.Extensions.IntegrationTests/NestedTransactorTests.cs
+++ b/test/Starcounter.Database.Extensions.IntegrationTests/NestedTransactorTests.cs
@@ -1,0 +1,36 @@
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Starcounter.Database.Extensions.IntegrationTests
+{
+    public sealed class NestedTransactorTests : ServicedTests
+    {
+        [Fact]
+        public void AllowNestedTransaction()
+        {
+            var transactor = CreateServices(
+                s => s.Decorate<ITransactor, NestedTransactor>())
+                .GetRequiredService<ITransactor>();
+
+            transactor.Transact(db =>
+            {
+                transactor.Transact(db => { });
+            });
+        }
+
+        [Fact]
+        public void ShouldRenderContextThatIndicatesNesting()
+        {
+            var transactor = CreateServices(
+                s => s.Decorate<ITransactor, NestedTransactor>())
+                .GetRequiredService<ITransactor>();
+
+            var nested = transactor.Transact(db =>
+            {
+                return transactor.Transact(db => db.IsNested());
+            });
+
+            Assert.True(nested);
+        }
+    }
+}

--- a/test/Starcounter.Database.Extensions.IntegrationTests/NestedTransactorTests.cs
+++ b/test/Starcounter.Database.Extensions.IntegrationTests/NestedTransactorTests.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -31,6 +32,29 @@ namespace Starcounter.Database.Extensions.IntegrationTests
             });
 
             Assert.True(nested);
+        }
+
+        [Fact]
+        public void ShouldRenderContextThatIndicatesNestingWhenRunningContinuation()
+        {
+            var transactor = CreateServices(
+                s => s.Decorate<ITransactor, NestedTransactor>())
+                .GetRequiredService<ITransactor>();
+
+            // This execute as a top-level transaction, saving the context as
+            // a thread local.
+            var t = transactor.Transact(async db =>
+            {
+                // Yield to force continuation to be scheduled and
+                // hence assure we test actual asynchronous execution.
+                await Task.Yield();
+
+                // Inner transactor should find original context when
+                // back on original thread.
+                return transactor.Transact(db => db.IsNested());
+            });
+
+            Assert.True(t.GetAwaiter().GetResult());
         }
     }
 }

--- a/test/Starcounter.Database.Extensions.IntegrationTests/OnDeleteTransactorTests.cs
+++ b/test/Starcounter.Database.Extensions.IntegrationTests/OnDeleteTransactorTests.cs
@@ -6,15 +6,16 @@ namespace Starcounter.Database.Extensions.IntegrationTests
 {
     public sealed class OnDeleteTransactorTests : ServicedTests
     {
-        public OnDeleteTransactorTests(DatabaseExtensionsIntegrationTestContext context) : base(context) {}
+        public OnDeleteTransactorTests(DatabaseExtensionsIntegrationTestContext context) : base(context) { }
 
-        [Database] public abstract class Person : IDeleteAware
+        [Database]
+        public abstract class Person : IDeleteAware
         {
             [ProxyState]
             Action<Person> _whenDeleted;
 
             public void WhenDeleted(Action<Person> action) => _whenDeleted = action;
-            
+
             public void OnDelete(IDatabaseContext db) => _whenDeleted?.Invoke(this);
         }
 
@@ -31,7 +32,7 @@ namespace Starcounter.Database.Extensions.IntegrationTests
 
                 var deleted = false;
                 p.WhenDeleted(p => deleted = true);
-                
+
                 db.Delete(p);
 
                 return deleted;

--- a/test/Starcounter.Database.Extensions.IntegrationTests/PreCommitTransactorTests.cs
+++ b/test/Starcounter.Database.Extensions.IntegrationTests/PreCommitTransactorTests.cs
@@ -1,4 +1,4 @@
-using System;
+using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -6,37 +6,39 @@ namespace Starcounter.Database.Extensions.IntegrationTests
 {
     public sealed class PreCommitTransactorTests : ServicedTests
     {
-        public abstract class Person
-        {
-            public bool WasHooked { get; set; }
-        }
+        public PreCommitTransactorTests(DatabaseExtensionsIntegrationTestContext context) : base(context) {}
+
+        [Database]
+        public abstract class Person { }
 
         [Fact]
         public void TriggerCallbackOnInsert()
         {
+            var hooked = new List<ulong>();
+            
             // Given
             var services = CreateServices
             (
                 serviceCollection => serviceCollection
                     .Configure<PreCommitOptions>(o => o.Hook<Person>((db, change) =>
                     {
-                        var p = db.Get<Person>(change.Oid);
-                        p.WasHooked = true;
+                        hooked.Add(change.Oid);
                     }))
                     .Decorate<ITransactor, PreCommitTransactor>()
             );
             var transactor = services.GetRequiredService<ITransactor>();
 
             // Act
-            Tuple<bool, ulong> before = transactor.Transact(db =>
+            (bool WasHooked, ulong Id) before = transactor.Transact(db =>
             {
                 var p = db.Insert<Person>();
-                return Tuple.Create(p.WasHooked, db.GetOid(p));
+                var id = db.GetOid(p);
+                return (hooked.Contains(id), id);
             });
 
             // Assert
-            var after = transactor.Transact(db => db.Get<Person>(before.Item2).WasHooked);
-            Assert.False(before.Item1);
+            var after = transactor.Transact(db => hooked.Contains(before.Id));
+            Assert.False(before.WasHooked);
             Assert.True(after);
         }
     }

--- a/test/Starcounter.Database.Extensions.IntegrationTests/PreCommitTransactorTests.cs
+++ b/test/Starcounter.Database.Extensions.IntegrationTests/PreCommitTransactorTests.cs
@@ -6,7 +6,7 @@ namespace Starcounter.Database.Extensions.IntegrationTests
 {
     public sealed class PreCommitTransactorTests : ServicedTests
     {
-        public PreCommitTransactorTests(DatabaseExtensionsIntegrationTestContext context) : base(context) {}
+        public PreCommitTransactorTests(DatabaseExtensionsIntegrationTestContext context) : base(context) { }
 
         [Database]
         public abstract class Person { }
@@ -15,7 +15,7 @@ namespace Starcounter.Database.Extensions.IntegrationTests
         public void TriggerCallbackOnInsert()
         {
             var hooked = new List<ulong>();
-            
+
             // Given
             var services = CreateServices
             (

--- a/test/Starcounter.Database.Extensions.IntegrationTests/ServicedTests.cs
+++ b/test/Starcounter.Database.Extensions.IntegrationTests/ServicedTests.cs
@@ -1,16 +1,35 @@
 using System;
 using Microsoft.Extensions.DependencyInjection;
+using Xunit;
 
 namespace Starcounter.Database.Extensions.IntegrationTests
 {
+    [Collection(nameof(DatabaseExtensionsIntegrationTestContext))]
     public abstract class ServicedTests
     {
-        protected IServiceProvider CreateServices(Func<IServiceCollection, IServiceCollection> configurator = null)
+        readonly DatabaseExtensionsIntegrationTestContext _testContext;
+
+        public ServicedTests(DatabaseExtensionsIntegrationTestContext context) => _testContext = context;
+
+        protected IServiceProvider CreateServices
+        (
+            Func<IServiceCollection, IServiceCollection> configurator = null, 
+            bool withRealTemporaryDatabase = true
+        )
         {
-            var services = new ServiceCollection()
-                .AddSingleton<DbStorage>()
-                .AddSingleton<DbProxyTypeGenerator>()
-                .AddSingleton<ITransactor, DbTransactor>();
+            IServiceCollection services = new ServiceCollection();
+            
+            if (withRealTemporaryDatabase)
+            {
+                services.AddSingleton<ITransactor>(sp => _testContext.Services.GetRequiredService<ITransactor>());
+            }
+            else
+            {
+                services
+                    .AddSingleton<DbStorage>()
+                    .AddSingleton<DbProxyTypeGenerator>()
+                    .AddSingleton<ITransactor, DbTransactor>();
+            }
 
             if (configurator != null)
             {

--- a/test/Starcounter.Database.Extensions.IntegrationTests/ServicedTests.cs
+++ b/test/Starcounter.Database.Extensions.IntegrationTests/ServicedTests.cs
@@ -13,12 +13,12 @@ namespace Starcounter.Database.Extensions.IntegrationTests
 
         protected IServiceProvider CreateServices
         (
-            Func<IServiceCollection, IServiceCollection> configurator = null, 
+            Func<IServiceCollection, IServiceCollection> configurator = null,
             bool withRealTemporaryDatabase = true
         )
         {
             IServiceCollection services = new ServiceCollection();
-            
+
             if (withRealTemporaryDatabase)
             {
                 services.AddSingleton<ITransactor>(sp => _testContext.Services.GetRequiredService<ITransactor>());

--- a/test/Starcounter.Database.Extensions.IntegrationTests/Starcounter.Database.Extensions.IntegrationTests.csproj
+++ b/test/Starcounter.Database.Extensions.IntegrationTests/Starcounter.Database.Extensions.IntegrationTests.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Scrutor" Version="3.2.0" />
+    <PackageReference Include="Starcounter.Database" Version="3.0.0-rc-*" />
     <PackageReference Include="Starcounter.Database.TestResources" Version="3.0.0-rc-*" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />

--- a/test/Starcounter.Database.Extensions.IntegrationTests/Starcounter.Database.Extensions.IntegrationTests.csproj
+++ b/test/Starcounter.Database.Extensions.IntegrationTests/Starcounter.Database.Extensions.IntegrationTests.csproj
@@ -16,6 +16,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Starcounter.Database.Extensions\Starcounter.Database.Extensions.csproj" />
+    <ProjectReference Include="..\..\..\Starcounter.Nova\src\Starcounter.Database\Starcounter.Database.csproj" />
+    <ProjectReference Include="..\..\..\Starcounter.Nova\test\TestUtilities\TestUtilities.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/Starcounter.Database.Extensions.IntegrationTests/Starcounter.Database.Extensions.IntegrationTests.csproj
+++ b/test/Starcounter.Database.Extensions.IntegrationTests/Starcounter.Database.Extensions.IntegrationTests.csproj
@@ -16,8 +16,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Starcounter.Database.Extensions\Starcounter.Database.Extensions.csproj" />
-    <ProjectReference Include="..\..\..\Starcounter.Nova\src\Starcounter.Database\Starcounter.Database.csproj" />
-    <ProjectReference Include="..\..\..\Starcounter.Nova\test\TestUtilities\TestUtilities.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/Starcounter.Database.Extensions.IntegrationTests/Starcounter.Database.Extensions.IntegrationTests.csproj
+++ b/test/Starcounter.Database.Extensions.IntegrationTests/Starcounter.Database.Extensions.IntegrationTests.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Scrutor" Version="3.2.0" />
+    <PackageReference Include="Starcounter.Database.TestResources" Version="3.0.0-rc-*" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.collector" Version="1.0.1" />


### PR DESCRIPTION
As issued in #9.

I'm still not sure how we should push this thing, since all options seem, well, not great. 

To do real integration testing of these extensions, we need to either duplicate all testing utilities we have in Nova, or expose them somehow, to tests we have here. Right now, I locally just reference the Nova sources, and have switched focus to write tests on nested transactions, including the incorporated Rollback() functionality.

For now, I've pushed a temporary commit, so if you put this repo as a sibling of `Starcounter.Nova`, it should work to run the integration tests. We shouldn't merge that though.

Please review and test NestedTransactorTests mainly. Once we have proper testing of that in isolation, I'll extend multi-decorator tests with similar capabilities.

(Also note that this is branched off of `issue/6`, which is the implementation of nested transactions in the first place. I'll probably merge them in order once we see integration tests work well).