### PR TITLE
Pre-commit hooks should not be invoked when transaction is aborted

### DIFF
--- a/src/Starcounter.Database.Extensions/PreCommitTransactor.cs
+++ b/src/Starcounter.Database.Extensions/PreCommitTransactor.cs
@@ -36,9 +36,9 @@ namespace Starcounter.Database.Extensions
 
         protected override void LeaveContext(IDatabaseContext db, bool exceptionThrown)
         {
-            if (!exceptionThrown && db is PreCommitContext context)
+            if (!exceptionThrown)
             {
-                context.ExecutePreCommitHooks(hookOptions);
+                ((PreCommitContext)db).ExecutePreCommitHooks(hookOptions);
             }
         }
     }

--- a/src/Starcounter.Database.Extensions/PreCommitTransactor.cs
+++ b/src/Starcounter.Database.Extensions/PreCommitTransactor.cs
@@ -35,6 +35,11 @@ namespace Starcounter.Database.Extensions
         protected override IDatabaseContext EnterContext(IDatabaseContext db) => new PreCommitContext(db);
 
         protected override void LeaveContext(IDatabaseContext db, bool exceptionThrown)
-            => ((PreCommitContext)db).ExecutePreCommitHooks(hookOptions);
+        {
+            if (!exceptionThrown && db is PreCommitContext context)
+            {
+                context.ExecutePreCommitHooks(hookOptions);
+            }
+        }
     }
 }


### PR DESCRIPTION
Issued in https://github.com/Starcounter/Starcounter.Database.Extensions/issues/12.