### PR TITLE
Enhance NestedTransactor decorator to automatically restart parent read-only transaction

### DIFF
--- a/samples/NestedTransactions/Program.cs
+++ b/samples/NestedTransactions/Program.cs
@@ -25,11 +25,23 @@ namespace NestedTransactions
 
             var transactor = services.GetRequiredService<ITransactor>();
 
+            NestedTransactionWithinReadWriteTransaction(transactor);
+            Console.WriteLine("----");
+            NestedTransactionWithinReadOnlyTransaction(transactor);
+        }
+
+        /// <summary>
+        /// Within a read-write database transaction,
+        /// inner transactor.Transact runs as a part of the parent transaction.
+        /// </summary>
+        /// <param name="transactor"></param>
+        static void NestedTransactionWithinReadWriteTransaction(ITransactor transactor)
+        {
             transactor.Transact(db =>
             {
                 var jane = db.Insert<Person>();
                 jane.Name = "Jane Doe";
-                
+
                 transactor.Transact(db =>
                 {
                     // Without NestedTransactor, this would execute as a new, independent
@@ -46,14 +58,14 @@ namespace NestedTransactions
 
                     // You can use extension IsNested() if you need to check if the
                     // current scope is a nested transaction.
-                    
+
                     Console.WriteLine(db.IsNested());
                     Console.WriteLine(john.BestFriend.Name);
                 });
 
                 // This will return false, because we are executing a top-level
                 // transaction.
-                
+
                 Console.WriteLine(db.IsNested());
             });
 
@@ -61,6 +73,34 @@ namespace NestedTransactions
             // True
             // Jane Doe
             // False
+        }
+
+        /// <summary>
+        /// Within a read-only database transaction,
+        /// inner transactor.Transact runs as a separate transaction.
+        /// The parent read-only transaction is rebased after each inner trasaction.
+        /// </summary>
+        /// <param name="transactor"></param>
+        static void NestedTransactionWithinReadOnlyTransaction(ITransactor transactor)
+        {
+            transactor.Transact(db =>
+            {
+                Person p = null;
+
+                transactor.Transact(idb =>
+                {
+                    p = db.Insert<Person>();
+                });
+
+                Console.WriteLine($"Oid: {db.GetOid(p)}, Name: {p.Name}");
+
+                transactor.Transact(idb =>
+                {
+                    p.Name = "Test";
+                });
+
+                Console.WriteLine($"Oid: {db.GetOid(p)}, Name: {p.Name}");
+            }, new TransactOptions(TransactionFlags.ReadOnly));
         }
     }
 }

--- a/src/Starcounter.Database.Extensions/NestedTransactor.cs
+++ b/src/Starcounter.Database.Extensions/NestedTransactor.cs
@@ -39,6 +39,13 @@ namespace Starcounter.Database.Extensions
         {
             IDatabaseContext nested = _current.Value?.DatabaseContext;
 
+            if (Data.Transaction.Current != null && (Data.Transaction.Current.Flags & TransactionFlags.ReadOnly) != 0)
+            {
+                base.Transact(action, options);
+                Data.Transaction.Current.Restart();
+                return;
+            }
+
             if (nested == null)
             {
                 base.Transact(action, options);
@@ -231,7 +238,7 @@ namespace Starcounter.Database.Extensions
 
         void FailOuterIfInnerFailed()
         {
-            if (_current.Value.InnerException != null)
+            if (_current.Value?.InnerException != null)
             {
                 throw new TransactionAbortedException("Nested transaction failed", _current.Value.InnerException);
             }

--- a/src/Starcounter.Database.Extensions/Starcounter.Database.Extensions.csproj
+++ b/src/Starcounter.Database.Extensions/Starcounter.Database.Extensions.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.2" />
+    <PackageReference Include="Starcounter.Database.Data" Version="3.0.0-rc-*" />
     <PackageReference Include="Starcounter.Database.Abstractions" Version="3.0.0-rc-*" />
   </ItemGroup>
   


### PR DESCRIPTION
This is supposed to unify all `ITransactor.Transact` API for the PALMA project. With such decorator they can use the same API call in all three cases:

- No database transaction.
- Within a read-only database transaction.
- Within a read-write database tranasction.