### PR TITLE
Don't collect/invoke post-commit hooks if Transact raises 

### DIFF
--- a/test/Starcounter.Database.Extensions.IntegrationTests/PostCommitTransactorTests.cs
+++ b/test/Starcounter.Database.Extensions.IntegrationTests/PostCommitTransactorTests.cs
@@ -2,8 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
-using Moq;
-using Moq.Protected;
 using Xunit;
 
 namespace Starcounter.Database.Extensions.IntegrationTests
@@ -50,24 +48,34 @@ namespace Starcounter.Database.Extensions.IntegrationTests
             Assert.True(after);
         }
 
+        class CountingTaskScheduler : TaskScheduler 
+        {
+            public int TaskCount { get; set; }
+
+            protected override void QueueTask(Task task) 
+            {
+                TaskCount++;
+                TryExecuteTask(task);
+            }
+
+            protected override IEnumerable<Task> GetScheduledTasks() => null;
+
+            protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued) => true;
+        }
+
         [Fact]
         public void DontInvokeHooksWhenTransactRaiseException()
         {
-            var count = 0;
-            var schedulerMoch = new Mock<TaskScheduler>();
-            schedulerMoch
-                .Protected()
-                .Setup("QueueTask", ItExpr.IsAny<Task>())
-                .Callback(() => count++);
+            var scheduler = new CountingTaskScheduler();
 
             // Given
             var services = CreateServices
             (
                 serviceCollection => serviceCollection
-                    .Configure<PostCommitOptions>(o =>
-                    {
-                        o.TaskScheduler = schedulerMoch.Object;
-                        o.Hook<Person>(_ => { });
+                    .Configure<PostCommitOptions>(o => 
+                    { 
+                        o.TaskScheduler = scheduler;
+                        o.Hook<Person>(_ => {});
                     })
                     .Decorate<ITransactor, PostCommitTransactor>()
             );
@@ -83,10 +91,9 @@ namespace Starcounter.Database.Extensions.IntegrationTests
             }));
 
             // Assert
-            Assert.Equal(0, count);
-
             var existInDatabase = transactor.Transact(db => db.Get<Person>(id) != null);
             Assert.False(existInDatabase);
+            Assert.Equal(0, scheduler.TaskCount);
         }
     }
 }

--- a/test/Starcounter.Database.Extensions.IntegrationTests/PostCommitTransactorTests.cs
+++ b/test/Starcounter.Database.Extensions.IntegrationTests/PostCommitTransactorTests.cs
@@ -89,10 +89,8 @@ namespace Starcounter.Database.Extensions.IntegrationTests
                 id = db.GetOid(p);
                 throw new Exception();
             }));
-
+            
             // Assert
-            var existInDatabase = transactor.Transact(db => db.Get<Person>(id) != null);
-            Assert.False(existInDatabase);
             Assert.Equal(0, scheduler.TaskCount);
         }
     }

--- a/test/Starcounter.Database.Extensions.IntegrationTests/Starcounter.Database.Extensions.IntegrationTests.csproj
+++ b/test/Starcounter.Database.Extensions.IntegrationTests/Starcounter.Database.Extensions.IntegrationTests.csproj
@@ -8,7 +8,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="Moq" Version="4.14.1" />
     <PackageReference Include="Scrutor" Version="3.2.0" />
     <PackageReference Include="Starcounter.Database" Version="3.0.0-rc-*" />
     <PackageReference Include="Starcounter.Database.TestResources" Version="3.0.0-rc-*" />


### PR DESCRIPTION
@miyconst 

The `Moq` replacement didn't work properly. It looked like it worked because the callback was invoked _after_ the assert, because the mocked scheduler did not render synchronous behavior.

I made an attempt to tweak it to that, but then mocking code became approximately as many lines as the explicit counting custom scheduler, and then the explicit one is easier to read.

Now I'v also extended `PostCommitTransactor` to actually omit hook invocation for failing transactions, and test shows green.

(I also fixed a bug in the test, removing the second transaction - that one _would_ of course render a call to hooks, because it didn't throw any exception, so test came out red because of that. Removing it was fine though - we test that same thing elsewhere already).